### PR TITLE
fix: add runtime scope to PostgreSQL dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.3</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file by setting the `postgresql` dependency to be used only at runtime instead of at compile time. This helps reduce the dependency scope and can improve build performance.

* Changed the `postgresql` dependency scope to `runtime` in `pom.xml`.